### PR TITLE
Shanjaq/ring spawner

### DIFF
--- a/h2/artifact.hc
+++ b/h2/artifact.hc
@@ -638,7 +638,39 @@ None
 
 void item_spawner_use(void)
 {
-	DropBackpack();
+	entity the_item, oldself;
+	
+	if (self.spawnflags & 1)
+	{
+		the_item = spawn();
+		setorigin(the_item, self.origin);
+		the_item.cnt_torch = self.cnt_torch;
+		the_item.cnt_h_boost = self.cnt_h_boost;
+		the_item.cnt_sh_boost = self.cnt_sh_boost;
+		the_item.cnt_mana_boost = self.cnt_mana_boost;
+		the_item.cnt_teleport = self.cnt_teleport;
+		the_item.cnt_tome = self.cnt_tome;
+		the_item.cnt_summon = self.cnt_summon;
+		the_item.cnt_invisibility = self.cnt_invisibility;
+		the_item.cnt_glyph = self.cnt_glyph;
+		the_item.cnt_haste = self.cnt_haste;
+		the_item.cnt_blast = self.cnt_blast;
+		the_item.cnt_polymorph = self.cnt_polymorph;
+		the_item.cnt_flight = self.cnt_flight;
+		the_item.cnt_cubeofforce = self.cnt_cubeofforce;
+		the_item.cnt_invincibility = self.cnt_invincibility;
+		the_item.ring_flight = self.ring_flight;
+		the_item.ring_water = self.ring_water;
+		the_item.ring_turning = self.ring_turning;
+		the_item.ring_regeneration = self.ring_regeneration;
+		
+		oldself = self;
+		self = the_item;
+		DropBackpack();
+		self = oldself;
+	}
+	else
+		DropBackpack();
 }
 
 /*QUAKED item_spawner (.0 .0 .5) (-8 -8 -44) (8 8 20) 

--- a/h2/items.hc
+++ b/h2/items.hc
@@ -1533,6 +1533,30 @@ void DropBackpack(void)
 //	total = 1;
 //	item.cnt_tome = 1;
 
+	if (self.ring_flight > 0)
+	{
+		total += 1;
+		item.ring_flight = self.ring_flight;
+	}
+
+	if (self.ring_water > 0)
+	{
+		total += 1;
+		item.ring_water = self.ring_water;
+	}
+
+	if (self.ring_turning > 0)
+	{
+		total += 1;
+		item.ring_turning = self.ring_turning;
+	}
+
+	if (self.ring_regeneration > 0)
+	{
+		total += 1;
+		item.ring_regeneration = self.ring_regeneration;
+	}
+
 	if (!total && !item.bluemana && !item.greenmana && !item.spawn_health) 
 	{	// Nothing to put in the backpack
 		remove(item);
@@ -1651,6 +1675,22 @@ void DropBackpack(void)
 		else if (item.armor_helmet)
 		{
 			spawn_item_armor_helmet();
+		}
+		else if (item.ring_water)
+		{
+			Ring_Init ( "models/ringwb.mdl", STR_RINGWATERBREATHING);
+		}
+		else if (item.ring_flight)
+		{
+			Ring_Init ( "models/ringft.mdl", STR_RINGFLIGHT);
+		}
+		else if (item.ring_regeneration)
+		{
+			Ring_Init ( "models/ringre.mdl", STR_RINGREGENERATION);
+		}
+		else if (item.ring_turning)
+		{
+			Ring_Init ( "models/ringtn.mdl", STR_RINGTURNING);
 		}
 		else
 		{

--- a/h2/items.hc
+++ b/h2/items.hc
@@ -1746,5 +1746,10 @@ void DropBackpack(void)
 	self.bluemana=0;
 	self.greenmana=0;
 	self.spawn_health=0;
+
+	self.ring_water=0;
+	self.ring_flight=0;
+	self.ring_regeneration=0;
+	self.ring_turning=0;	
 }
 

--- a/h2/precache.hc
+++ b/h2/precache.hc
@@ -856,7 +856,10 @@ void Precache_mdl (void)
 //	precache_model("models/a_xray.mdl");
 	precache_model("models/a_invis.mdl");
 	precache_model("models/cube.mdl");
+	precache_model("models/ringwb.mdl");
 	precache_model("models/ringft.mdl");
+	precache_model("models/ringre.mdl");
+	precache_model("models/ringtn.mdl");
 
 	//Lambinator
 	precache_model("models/sheep.mdl");

--- a/h2/proto.hc
+++ b/h2/proto.hc
@@ -69,4 +69,4 @@ vector aim_adjust (entity targ);
 void()respawn;
 void()GibPlayer;
 void stats_NewClass(entity e);
-
+void Ring_Init(string modelname,string name);

--- a/portals/artifact.hc
+++ b/portals/artifact.hc
@@ -11,7 +11,6 @@
  */
 void() SUB_regen;
 void() StartItem;
-void() Ring_Flight;
 void ring_touch(void);
 
 void artifact_touch()

--- a/portals/artifact.hc
+++ b/portals/artifact.hc
@@ -11,6 +11,7 @@
  */
 void() SUB_regen;
 void() StartItem;
+void() Ring_Flight;
 void ring_touch(void);
 
 void artifact_touch()
@@ -686,7 +687,39 @@ void art_sword_and_crown()
 
 void item_spawner_use(void)
 {
-	DropBackpack();
+	entity the_item, oldself;
+	
+	if (self.spawnflags & 1)
+	{
+		the_item = spawn();
+		setorigin(the_item, self.origin);
+		the_item.cnt_torch = self.cnt_torch;
+		the_item.cnt_h_boost = self.cnt_h_boost;
+		the_item.cnt_sh_boost = self.cnt_sh_boost;
+		the_item.cnt_mana_boost = self.cnt_mana_boost;
+		the_item.cnt_teleport = self.cnt_teleport;
+		the_item.cnt_tome = self.cnt_tome;
+		the_item.cnt_summon = self.cnt_summon;
+		the_item.cnt_invisibility = self.cnt_invisibility;
+		the_item.cnt_glyph = self.cnt_glyph;
+		the_item.cnt_haste = self.cnt_haste;
+		the_item.cnt_blast = self.cnt_blast;
+		the_item.cnt_polymorph = self.cnt_polymorph;
+		the_item.cnt_flight = self.cnt_flight;
+		the_item.cnt_cubeofforce = self.cnt_cubeofforce;
+		the_item.cnt_invincibility = self.cnt_invincibility;
+		the_item.ring_flight = self.ring_flight;
+		the_item.ring_water = self.ring_water;
+		the_item.ring_turning = self.ring_turning;
+		the_item.ring_regeneration = self.ring_regeneration;
+		
+		oldself = self;
+		self = the_item;
+		DropBackpack();
+		self = oldself;
+	}
+	else
+		DropBackpack();
 }
 
 /*QUAKED item_spawner (.0 .0 .5) (-8 -8 -44) (8 8 20) 
@@ -706,4 +739,3 @@ void item_spawner()
 	
 	self.use = item_spawner_use;
 }
-

--- a/portals/items.hc
+++ b/portals/items.hc
@@ -1550,6 +1550,30 @@ float total;
 	item.spawn_health = self.spawn_health;
 
 
+	if (self.ring_flight > 0)
+	{
+		total += 1;
+		item.ring_flight = self.ring_flight;
+	}
+
+	if (self.ring_water > 0)
+	{
+		total += 1;
+		item.ring_water = self.ring_water;
+	}
+
+	if (self.ring_turning > 0)
+	{
+		total += 1;
+		item.ring_turning = self.ring_turning;
+	}
+
+	if (self.ring_regeneration > 0)
+	{
+		total += 1;
+		item.ring_regeneration = self.ring_regeneration;
+	}
+	
 	if (!total && !item.bluemana && !item.greenmana && !item.spawn_health) 
 		if(self.classname!="player")
 			total=RandomMonsterGoodies();
@@ -1676,6 +1700,22 @@ float total;
 		{
 			spawn_item_armor_helmet();
 		}
+		else if (item.ring_water)
+		{
+			Ring_Init ( "models/ringwb.mdl", STR_RINGWATERBREATHING);
+		}
+		else if (item.ring_flight)
+		{
+			Ring_Init ( "models/ringft.mdl", STR_RINGFLIGHT);
+		}
+		else if (item.ring_regeneration)
+		{
+			Ring_Init ( "models/ringre.mdl", STR_RINGREGENERATION);
+		}
+		else if (item.ring_turning)
+		{
+			Ring_Init ( "models/ringtn.mdl", STR_RINGTURNING);
+		}
 		else
 		{
 			dprint("Bad backpack!");
@@ -1729,5 +1769,9 @@ float total;
 	self.bluemana=0;
 	self.greenmana=0;
 	self.spawn_health=0;
+	self.ring_water=0;
+	self.ring_flight=0;
+	self.ring_regeneration=0;
+	self.ring_turning=0;
 }
 

--- a/portals/items.hc
+++ b/portals/items.hc
@@ -1769,6 +1769,7 @@ float total;
 	self.bluemana=0;
 	self.greenmana=0;
 	self.spawn_health=0;
+	
 	self.ring_water=0;
 	self.ring_flight=0;
 	self.ring_regeneration=0;

--- a/portals/precache.hc
+++ b/portals/precache.hc
@@ -716,7 +716,11 @@ void Precache_misc (void)
 	precache_model("models/cube.mdl");
 	precache_model("models/ringft.mdl");
 	precache_model("models/glyphwir.mdl");	//Tripwire version of glyph
-
+	precache_model("models/ringwb.mdl");
+	precache_model("models/ringft.mdl");
+	precache_model("models/ringre.mdl");
+	precache_model("models/ringtn.mdl");
+	
 	//Lambinator
 	precache_model("models/sheep.mdl");
 	precache_model("models/snout.mdl");


### PR DESCRIPTION
extend item_spawner to be repeatable with spawnflags |= 1, also add rings to be spawnable with properties: {ring_flight, ring_water, ring_turning, ring_regeneration} > 0;

note: Rings will only spawn if there are no other artifacts specified.