### PR TITLE
Various small fixes

### DIFF
--- a/h2/explode.hc
+++ b/h2/explode.hc
@@ -9,8 +9,9 @@ void()BlowUp=
 		self.scale=self.dmg;
 	    T_RadiusDamage (self, self.owner, self.dmg*100, world);
 		self.dmg += 0.1;
-		if(self.enemy)	//Stay with enemy;
-			setorigin(self,self.enemy.origin+self.view_ofs);
+		if(self.enemy)
+			if(self.enemy.health>0&&self.enemy.flags2&FL_ALIVE)//Stay with enemy;
+				setorigin(self,self.enemy.origin+self.view_ofs);
 		self.think=BlowUp;
 		thinktime self : 0.025;
 	}

--- a/h2/items.hc
+++ b/h2/items.hc
@@ -265,7 +265,7 @@ WEAPONS
 ===============================================================================
 */
 
-float MAX_INV = 25;
+float MAX_INV = 15;		//ws: changed from 25 because most items actually have a cap of 15 in artifacts.hc
 
 void max_ammo2 (entity AddTo, entity AddFrom)
 {
@@ -273,7 +273,9 @@ void max_ammo2 (entity AddTo, entity AddFrom)
 
 	if (AddTo.cnt_torch + AddFrom.cnt_torch > MAX_INV)
 		AddFrom.cnt_torch = MAX_INV - AddTo.cnt_torch;
-	if (AddTo.cnt_h_boost + AddFrom.cnt_h_boost > MAX_INV)
+	if (AddTo.playerclass==CLASS_CRUSADER && AddTo.cnt_h_boost + AddFrom.cnt_h_boost > 30)
+		AddFrom.cnt_h_boost = 30 - AddTo.cnt_h_boost;
+	else if (AddTo.cnt_h_boost + AddFrom.cnt_h_boost > MAX_INV)
 		AddFrom.cnt_h_boost = MAX_INV - AddTo.cnt_h_boost;
 	if (AddTo.cnt_sh_boost + AddFrom.cnt_sh_boost > MAX_INV)
 		AddFrom.cnt_sh_boost = MAX_INV - AddTo.cnt_sh_boost;
@@ -287,7 +289,9 @@ void max_ammo2 (entity AddTo, entity AddFrom)
 		AddFrom.cnt_summon = MAX_INV - AddTo.cnt_summon;
 	if (AddTo.cnt_invisibility + AddFrom.cnt_invisibility > MAX_INV)
 		AddFrom.cnt_invisibility = MAX_INV - AddTo.cnt_invisibility;
-	if (AddTo.cnt_glyph + AddFrom.cnt_glyph > MAX_INV)
+	if (AddTo.playerclass==CLASS_CRUSADER && AddTo.cnt_glyph + AddFrom.cnt_glyph > 50)
+		AddFrom.cnt_glyph = 50 - AddTo.cnt_glyph;
+	else if (AddTo.cnt_glyph + AddFrom.cnt_glyph > MAX_INV)
 		AddFrom.cnt_glyph = MAX_INV - AddTo.cnt_glyph;
 	if (AddTo.cnt_haste + AddFrom.cnt_haste > MAX_INV)
 		AddFrom.cnt_haste = MAX_INV - AddTo.cnt_haste;

--- a/h2/mummy.hc
+++ b/h2/mummy.hc
@@ -473,6 +473,8 @@ void mummy_pain(void)
 
 	if (hold_parts != self.parts_gone)
 		sound (self, CHAN_BODY, "mummy/limbloss.wav", 1, ATTN_NORM);
+	
+	self.pain_finished = time+random(0.3,0.8);
 }
 
 

--- a/h2/purifier.hc
+++ b/h2/purifier.hc
@@ -417,7 +417,7 @@ void() pal_purifier_fire =
 	if ((self.artifact_active & ART_TOMEOFPOWER) &&
 		(self.greenmana >= 8) && (self.bluemana >= 8))
 		purifier_tomefire();
-	else if ((self.greenmana >= 2) && (self.bluemana >= 2))
+	else if ((self.greenmana >= 1) && (self.bluemana >= 1))
 		purifier_rapidfire();
 
 	self.nextthink=time;

--- a/h2/scorpion.hc
+++ b/h2/scorpion.hc
@@ -408,6 +408,7 @@ void ScorpionPainDecide(void)
 	{
 		ScorpionPain();
 		sound(self, CHAN_VOICE, "scorpion/pain.wav", 1, ATTN_NORM);
+		self.pain_finished = time + 0.25;
 	}
 }
 

--- a/h2/sickle.hc
+++ b/h2/sickle.hc
@@ -173,7 +173,7 @@ void sickle_fire ()
 		WriteCoord (MSG_BROADCAST, org_z);
 
 		if (self.artifact_active & ART_TOMEOFPOWER)
-			CreateWhiteFlash(org);
+			CreateWhiteFlash(trace_endpos - v_forward*8);
 		else
 		{
 			org = trace_endpos + (v_forward * -1) + (v_right * 15);

--- a/h2/warhamer.hc
+++ b/h2/warhamer.hc
@@ -360,6 +360,12 @@ void warhammer_fire (string hitdir,vector ofs)
 		else if(ofs=='0 0 0')
 		{	// hit wall, add sparks?
 			sound (self, CHAN_WEAPON, "weapons/hitwall.wav", 1, ATTN_NORM);
+			CreateSpark (trace_endpos + v_forward*(-1) + v_right*10 + v_up*(-40));
+			WriteByte (MSG_BROADCAST, SVC_TEMPENTITY);
+			WriteByte (MSG_BROADCAST, TE_GUNSHOT);
+			WriteCoord (MSG_BROADCAST, org_x);
+			WriteCoord (MSG_BROADCAST, org_y);
+			WriteCoord (MSG_BROADCAST, org_z);
 		}
 	}
 }

--- a/h2/weapons.hc
+++ b/h2/weapons.hc
@@ -544,7 +544,7 @@ float W_CheckNoAmmo (float check_weapon)
 				if(self.bluemana >= 8 && self.greenmana >= 8)
 					return TRUE;
 			}
-			else if(self.bluemana >= 2 && self.greenmana >= 2)
+			else if(self.bluemana >= 1 && self.greenmana >= 1)
 					return TRUE;
 		}
 		else if (check_weapon==IT_WEAPON3)

--- a/hw/mummy.hc
+++ b/hw/mummy.hc
@@ -473,6 +473,8 @@ void mummy_pain(void)
 
 	if (hold_parts != self.parts_gone)
 		sound (self, CHAN_BODY, "mummy/limbloss.wav", 1, ATTN_NORM);
+	
+	self.pain_finished = time+random(0.3,0.8);
 }
 
 

--- a/hw/purifier.hc
+++ b/hw/purifier.hc
@@ -379,7 +379,7 @@ void() pal_purifier_fire =
 	if ((self.artifact_active & ART_TOMEOFPOWER) &&
 		(self.greenmana >= 8) && (self.bluemana >= 8))
 		purifier_tomefire();
-	else if ((self.greenmana >= 2) && (self.bluemana >= 2))
+	else if ((self.greenmana >= 1) && (self.bluemana >= 1))
 		purifier_rapidfire();
 
 	self.nextthink=time;

--- a/hw/scorpion.hc
+++ b/hw/scorpion.hc
@@ -408,6 +408,7 @@ void ScorpionPainDecide(void)
 	{
 		ScorpionPain();
 		sound(self, CHAN_VOICE, "scorpion/pain.wav", 1, ATTN_NORM);
+		self.pain_finished = time + 0.25;
 	}
 }
 
@@ -437,6 +438,8 @@ void ScorpionMelee(float damage)
 	makevectors (self.angles);
 	source = self.origin;
 	traceline (source, source + v_forward*60, FALSE, self);
+	if (trace_fraction == 1.0)
+		traceline (source + v_up*10, source + v_up*10 + v_forward*60, FALSE, self);  //ws: crouching players are no longer invulnerable
 
 	if (trace_ent != self.enemy) return;
 

--- a/hw/sickle.hc
+++ b/hw/sickle.hc
@@ -1,5 +1,5 @@
 /*
- * $Header: /cvsroot/uhexen2/gamecode/hc/portals/sickle.hc,v 1.3 2007-02-07 16:59:36 sezero Exp $
+ * $Header: /cvsroot/uhexen2/gamecode/hc/hw/sickle.hc,v 1.2 2007-02-07 16:58:02 sezero Exp $
  */
 
 /*
@@ -92,32 +92,15 @@ void sickle_fire ()
 
 			if (random() < chance)
 			{
-			//	point_chance = (self.level - 5) * 2;
-			//	if (point_chance > 10)
-			//		point_chance = 10;
-			/* Pa3PyX -- This HAS TO change: One will be dead 3 times
-			 * before stealing their 10 hit points at clvl 10 in 5 hits
-			 * trying to hack away at a medusa or an archer lord. This
-			 * has to be at least 20 to make any practical use of this
-			 * level 6 ability, and at most that, since spiders can be
-			 * leeched from fairly easily (but they will still caw at
-			 * you at least twice before your hit actually drains).
-			 * Given that you cannot leech from dead bodies.	*/
-				point_chance = (self.level - 5) * 4;
-				if (point_chance > 20)
-					point_chance = 20;
+				point_chance = (self.level - 5) * 2;
+				if (point_chance > 10)
+					point_chance = 10;
 
 				sound (self, CHAN_BODY, "weapons/drain.wav", 1, ATTN_NORM);
 
-			//	self.health += point_chance;
-			//	if (self.health>self.max_health)
-			//		self.health = self.max_health;
-			//	Pa3PyX: no longer cancel mystic urn effect
-				if (self.health < self.max_health) {
-					self.health += point_chance;
-					if (self.health>self.max_health)
-						self.health = self.max_health;
-				}
+				self.health += point_chance;
+				if (self.health>self.max_health)
+					self.health = self.max_health;
 			}
 		}
 
@@ -133,7 +116,7 @@ void sickle_fire ()
 			else
 				inertia=trace_ent.mass/10;
 
-			if ((trace_ent.hull != HULL_SCORPION) && (inertia<1000) && (trace_ent.classname != "breakable_brush"))
+			if ((trace_ent.hull != HULL_BIG) && (inertia<1000) && (trace_ent.classname != "breakable_brush"))
 			{
 				if (trace_ent.mass < 1000)
 				{
@@ -166,11 +149,13 @@ void sickle_fire ()
 	else
 	{	// hit wall
 		sound (self, CHAN_WEAPON, "weapons/hitwall.wav", 1, ATTN_NORM);
-		WriteByte (MSG_BROADCAST, SVC_TEMPENTITY);
-		WriteByte (MSG_BROADCAST, TE_GUNSHOT);
-		WriteCoord (MSG_BROADCAST, org_x);
-		WriteCoord (MSG_BROADCAST, org_y);
-		WriteCoord (MSG_BROADCAST, org_z);
+		WriteByte (MSG_MULTICAST, SVC_TEMPENTITY);
+		WriteByte (MSG_MULTICAST, TE_GUNSHOT);
+		WriteByte (MSG_MULTICAST, 1);
+		WriteCoord (MSG_MULTICAST, org_x);
+		WriteCoord (MSG_MULTICAST, org_y);
+		WriteCoord (MSG_MULTICAST, org_z);
+		multicast(self.origin,MULTICAST_PHS);
 
 		if (self.artifact_active & ART_TOMEOFPOWER)
 			CreateWhiteFlash(trace_endpos - v_forward*8);

--- a/hw/sickle.hc
+++ b/hw/sickle.hc
@@ -1,5 +1,5 @@
 /*
- * $Header: /cvsroot/uhexen2/gamecode/hc/hw/sickle.hc,v 1.2 2007-02-07 16:58:02 sezero Exp $
+ * $Header: /cvsroot/uhexen2/gamecode/hc/portals/sickle.hc,v 1.3 2007-02-07 16:59:36 sezero Exp $
  */
 
 /*
@@ -92,15 +92,32 @@ void sickle_fire ()
 
 			if (random() < chance)
 			{
-				point_chance = (self.level - 5) * 2;
-				if (point_chance > 10)
-					point_chance = 10;
+			//	point_chance = (self.level - 5) * 2;
+			//	if (point_chance > 10)
+			//		point_chance = 10;
+			/* Pa3PyX -- This HAS TO change: One will be dead 3 times
+			 * before stealing their 10 hit points at clvl 10 in 5 hits
+			 * trying to hack away at a medusa or an archer lord. This
+			 * has to be at least 20 to make any practical use of this
+			 * level 6 ability, and at most that, since spiders can be
+			 * leeched from fairly easily (but they will still caw at
+			 * you at least twice before your hit actually drains).
+			 * Given that you cannot leech from dead bodies.	*/
+				point_chance = (self.level - 5) * 4;
+				if (point_chance > 20)
+					point_chance = 20;
 
 				sound (self, CHAN_BODY, "weapons/drain.wav", 1, ATTN_NORM);
 
-				self.health += point_chance;
-				if (self.health>self.max_health)
-					self.health = self.max_health;
+			//	self.health += point_chance;
+			//	if (self.health>self.max_health)
+			//		self.health = self.max_health;
+			//	Pa3PyX: no longer cancel mystic urn effect
+				if (self.health < self.max_health) {
+					self.health += point_chance;
+					if (self.health>self.max_health)
+						self.health = self.max_health;
+				}
 			}
 		}
 
@@ -116,7 +133,7 @@ void sickle_fire ()
 			else
 				inertia=trace_ent.mass/10;
 
-			if ((trace_ent.hull != HULL_BIG) && (inertia<1000) && (trace_ent.classname != "breakable_brush"))
+			if ((trace_ent.hull != HULL_SCORPION) && (inertia<1000) && (trace_ent.classname != "breakable_brush"))
 			{
 				if (trace_ent.mass < 1000)
 				{
@@ -149,16 +166,14 @@ void sickle_fire ()
 	else
 	{	// hit wall
 		sound (self, CHAN_WEAPON, "weapons/hitwall.wav", 1, ATTN_NORM);
-		WriteByte (MSG_MULTICAST, SVC_TEMPENTITY);
-		WriteByte (MSG_MULTICAST, TE_GUNSHOT);
-		WriteByte (MSG_MULTICAST, 1);
-		WriteCoord (MSG_MULTICAST, org_x);
-		WriteCoord (MSG_MULTICAST, org_y);
-		WriteCoord (MSG_MULTICAST, org_z);
-		multicast(self.origin,MULTICAST_PHS);
+		WriteByte (MSG_BROADCAST, SVC_TEMPENTITY);
+		WriteByte (MSG_BROADCAST, TE_GUNSHOT);
+		WriteCoord (MSG_BROADCAST, org_x);
+		WriteCoord (MSG_BROADCAST, org_y);
+		WriteCoord (MSG_BROADCAST, org_z);
 
 		if (self.artifact_active & ART_TOMEOFPOWER)
-			CreateWhiteFlash(org);
+			CreateWhiteFlash(trace_endpos - v_forward*8);
 		else
 		{
 			org = trace_endpos + (v_forward * -1) + (v_right * 15);

--- a/hw/warhamer.hc
+++ b/hw/warhamer.hc
@@ -380,6 +380,12 @@ void warhammer_fire (string hitdir,vector ofs)
 		else if(ofs=='0 0 0')
 		{	// hit wall, add sparks?
 			sound (self, CHAN_WEAPON, "weapons/hitwall.wav", 1, ATTN_NORM);
+			CreateSpark (trace_endpos + v_forward*(-1) + v_right*10 + v_up*(-40));
+			WriteByte (MSG_BROADCAST, SVC_TEMPENTITY);
+			WriteByte (MSG_BROADCAST, TE_GUNSHOT);
+			WriteCoord (MSG_BROADCAST, org_x);
+			WriteCoord (MSG_BROADCAST, org_y);
+			WriteCoord (MSG_BROADCAST, org_z);
 		}
 	}
 }

--- a/hw/weapons.hc
+++ b/hw/weapons.hc
@@ -547,7 +547,7 @@ float W_CheckNoAmmo (float check_weapon)
 				if(self.bluemana >= 8 && self.greenmana >= 8)
 					return TRUE;
 			}
-			else if(self.bluemana >= 2 && self.greenmana >= 2)
+			else if(self.bluemana >= 1 && self.greenmana >= 1)
 					return TRUE;
 		break;
 		case IT_WEAPON3:

--- a/portals/items.hc
+++ b/portals/items.hc
@@ -1554,31 +1554,31 @@ float total;
 	item.spawn_health = self.spawn_health;
 
 
-	if (self.ring_flight > 0)	
-	{	
-		total += 1;	
-		item.ring_flight = self.ring_flight;	
-	}	
-
-	if (self.ring_water > 0)	
-	{	
-		total += 1;	
-		item.ring_water = self.ring_water;	
-	}	
-
-	if (self.ring_turning > 0)	
-	{	
-		total += 1;	
-		item.ring_turning = self.ring_turning;	
-	}	
-
-	if (self.ring_regeneration > 0)	
-	{	
-		total += 1;	
-		item.ring_regeneration = self.ring_regeneration;	
+	if (self.ring_flight > 0)
+	{
+		total += 1;
+		item.ring_flight = self.ring_flight;
 	}
 
-	if (!total && !item.bluemana && !item.greenmana && !item.spawn_health) 
+	if (self.ring_water > 0)
+	{
+		total += 1;
+		item.ring_water = self.ring_water;
+	}
+
+	if (self.ring_turning > 0)
+	{
+		total += 1;
+		item.ring_turning = self.ring_turning;
+	}
+
+	if (self.ring_regeneration > 0)
+	{
+		total += 1;
+		item.ring_regeneration = self.ring_regeneration;
+	}
+
+	if (!total && !item.bluemana && !item.greenmana && !item.spawn_health)
 		if(self.classname!="player")
 			total=RandomMonsterGoodies();
 

--- a/portals/items.hc
+++ b/portals/items.hc
@@ -1554,6 +1554,30 @@ float total;
 	item.spawn_health = self.spawn_health;
 
 
+	if (self.ring_flight > 0)	
+	{	
+		total += 1;	
+		item.ring_flight = self.ring_flight;	
+	}	
+
+	if (self.ring_water > 0)	
+	{	
+		total += 1;	
+		item.ring_water = self.ring_water;	
+	}	
+
+	if (self.ring_turning > 0)	
+	{	
+		total += 1;	
+		item.ring_turning = self.ring_turning;	
+	}	
+
+	if (self.ring_regeneration > 0)	
+	{	
+		total += 1;	
+		item.ring_regeneration = self.ring_regeneration;	
+	}
+
 	if (!total && !item.bluemana && !item.greenmana && !item.spawn_health) 
 		if(self.classname!="player")
 			total=RandomMonsterGoodies();

--- a/portals/items.hc
+++ b/portals/items.hc
@@ -275,7 +275,7 @@ WEAPONS
 ===============================================================================
 */
 
-float MAX_INV = 25;
+float MAX_INV = 15;		//ws: changed from 25 because most items actually have a cap of 15 in artifacts.hc
 
 void max_ammo2 (entity AddTo, entity AddFrom)
 {
@@ -283,10 +283,12 @@ void max_ammo2 (entity AddTo, entity AddFrom)
 
 	if (AddTo.cnt_torch + AddFrom.cnt_torch > MAX_INV)
 		AddFrom.cnt_torch = MAX_INV - AddTo.cnt_torch;
-	if (AddTo.cnt_h_boost + AddFrom.cnt_h_boost > MAX_INV)
+	if (AddTo.playerclass==CLASS_CRUSADER && AddTo.cnt_h_boost + AddFrom.cnt_h_boost > 30)
+		AddFrom.cnt_h_boost = 30 - AddTo.cnt_h_boost;
+	else if (AddTo.cnt_h_boost + AddFrom.cnt_h_boost > MAX_INV)
 		AddFrom.cnt_h_boost = MAX_INV - AddTo.cnt_h_boost;
-	if (AddTo.cnt_sh_boost + AddFrom.cnt_sh_boost > MAX_INV)
-		AddFrom.cnt_sh_boost = MAX_INV - AddTo.cnt_sh_boost;
+	if (AddTo.cnt_sh_boost + AddFrom.cnt_sh_boost > 5)
+		AddFrom.cnt_sh_boost = 5 - AddTo.cnt_sh_boost;
 	if (AddTo.cnt_mana_boost + AddFrom.cnt_mana_boost > MAX_INV)
 		AddFrom.cnt_mana_boost = MAX_INV - AddTo.cnt_mana_boost;
 	if (AddTo.cnt_teleport + AddFrom.cnt_teleport > MAX_INV)
@@ -297,7 +299,9 @@ void max_ammo2 (entity AddTo, entity AddFrom)
 		AddFrom.cnt_summon = MAX_INV - AddTo.cnt_summon;
 	if (AddTo.cnt_invisibility + AddFrom.cnt_invisibility > MAX_INV)
 		AddFrom.cnt_invisibility = MAX_INV - AddTo.cnt_invisibility;
-	if (AddTo.cnt_glyph + AddFrom.cnt_glyph > MAX_INV)
+	if (AddTo.playerclass==CLASS_CRUSADER && AddTo.cnt_glyph + AddFrom.cnt_glyph > 50)
+		AddFrom.cnt_glyph = 50 - AddTo.cnt_glyph;
+	else if (AddTo.cnt_glyph + AddFrom.cnt_glyph > MAX_INV)
 		AddFrom.cnt_glyph = MAX_INV - AddTo.cnt_glyph;
 	if (AddTo.cnt_haste + AddFrom.cnt_haste > MAX_INV)
 		AddFrom.cnt_haste = MAX_INV - AddTo.cnt_haste;
@@ -1550,30 +1554,6 @@ float total;
 	item.spawn_health = self.spawn_health;
 
 
-	if (self.ring_flight > 0)
-	{
-		total += 1;
-		item.ring_flight = self.ring_flight;
-	}
-
-	if (self.ring_water > 0)
-	{
-		total += 1;
-		item.ring_water = self.ring_water;
-	}
-
-	if (self.ring_turning > 0)
-	{
-		total += 1;
-		item.ring_turning = self.ring_turning;
-	}
-
-	if (self.ring_regeneration > 0)
-	{
-		total += 1;
-		item.ring_regeneration = self.ring_regeneration;
-	}
-	
 	if (!total && !item.bluemana && !item.greenmana && !item.spawn_health) 
 		if(self.classname!="player")
 			total=RandomMonsterGoodies();
@@ -1700,26 +1680,6 @@ float total;
 		{
 			spawn_item_armor_helmet();
 		}
-		else if (item.ring_water)
-		{
-			self.classname = "Ring_WaterBreathing";
-			Ring_Init ( "models/ringwb.mdl", STR_RINGWATERBREATHING);
-		}
-		else if (item.ring_flight)
-		{
-			self.classname = "Ring_Flight";
-			Ring_Init ( "models/ringft.mdl", STR_RINGFLIGHT);
-		}
-		else if (item.ring_regeneration)
-		{
-			self.classname = "Ring_Regeneration";
-			Ring_Init ( "models/ringre.mdl", STR_RINGREGENERATION);
-		}
-		else if (item.ring_turning)
-		{
-			self.classname = "Ring_Turning";
-			Ring_Init ( "models/ringtn.mdl", STR_RINGTURNING);
-		}
 		else
 		{
 			dprint("Bad backpack!");
@@ -1773,10 +1733,5 @@ float total;
 	self.bluemana=0;
 	self.greenmana=0;
 	self.spawn_health=0;
-	
-	self.ring_water=0;
-	self.ring_flight=0;
-	self.ring_regeneration=0;
-	self.ring_turning=0;
 }
 

--- a/portals/items.hc
+++ b/portals/items.hc
@@ -1704,6 +1704,26 @@ float total;
 		{
 			spawn_item_armor_helmet();
 		}
+		else if (item.ring_water)
+		{
+			self.classname = "Ring_WaterBreathing";
+			Ring_Init ( "models/ringwb.mdl", STR_RINGWATERBREATHING);
+		}
+		else if (item.ring_flight)
+		{
+			self.classname = "Ring_Flight";
+			Ring_Init ( "models/ringft.mdl", STR_RINGFLIGHT);
+		}
+		else if (item.ring_regeneration)
+		{
+			self.classname = "Ring_Regeneration";
+			Ring_Init ( "models/ringre.mdl", STR_RINGREGENERATION);
+		}
+		else if (item.ring_turning)
+		{
+			self.classname = "Ring_Turning";
+			Ring_Init ( "models/ringtn.mdl", STR_RINGTURNING);
+		}
 		else
 		{
 			dprint("Bad backpack!");

--- a/portals/mummy.hc
+++ b/portals/mummy.hc
@@ -475,6 +475,8 @@ void mummy_pain(void)
 
 	if (hold_parts != self.parts_gone)
 		sound (self, CHAN_BODY, "mummy/limbloss.wav", 1, ATTN_NORM);
+	
+	self.pain_finished = time+random(0.3,0.8);
 }
 
 

--- a/portals/purifier.hc
+++ b/portals/purifier.hc
@@ -419,7 +419,7 @@ void() pal_purifier_fire =
 	if ((self.artifact_active & ART_TOMEOFPOWER) &&
 		(self.greenmana >= 8) && (self.bluemana >= 8))
 		purifier_tomefire();
-	else if ((self.greenmana >= 2) && (self.bluemana >= 2))
+	else if ((self.greenmana >= 1) && (self.bluemana >= 1))
 		purifier_rapidfire();
 
 	self.nextthink=time;

--- a/portals/scorpion.hc
+++ b/portals/scorpion.hc
@@ -424,6 +424,7 @@ void ScorpionPainDecide(void)
 	{
 		ScorpionPain();
 		sound(self, CHAN_VOICE, "scorpion/pain.wav", 1, ATTN_NORM);
+		self.pain_finished = time + 0.25;
 	}
 }
 
@@ -453,6 +454,8 @@ void ScorpionMelee(float damage)
 	makevectors (self.angles);
 	source = self.origin;
 	traceline (source, source + v_forward*60, FALSE, self);
+	if (trace_fraction == 1.0)
+		traceline (source + v_up*10, source + v_up*10 + v_forward*60, FALSE, self);  //ws: crouching players are no longer invulnerable
 
 	if (trace_ent != self.enemy) return;
 

--- a/portals/sickle.hc
+++ b/portals/sickle.hc
@@ -173,7 +173,7 @@ void sickle_fire ()
 		WriteCoord (MSG_BROADCAST, org_z);
 
 		if (self.artifact_active & ART_TOMEOFPOWER)
-			CreateWhiteFlash(org);
+			CreateWhiteFlash(trace_endpos - v_forward*8);
 		else
 		{
 			org = trace_endpos + (v_forward * -1) + (v_right * 15);

--- a/portals/warhamer.hc
+++ b/portals/warhamer.hc
@@ -366,6 +366,12 @@ void warhammer_fire (string hitdir,vector ofs)
 		else if(ofs=='0 0 0')
 		{	// hit wall, add sparks?
 			sound (self, CHAN_WEAPON, "weapons/hitwall.wav", 1, ATTN_NORM);
+			CreateSpark (trace_endpos + v_forward*(-1) + v_right*10 + v_up*(-40));
+			WriteByte (MSG_BROADCAST, SVC_TEMPENTITY);
+			WriteByte (MSG_BROADCAST, TE_GUNSHOT);
+			WriteCoord (MSG_BROADCAST, org_x);
+			WriteCoord (MSG_BROADCAST, org_y);
+			WriteCoord (MSG_BROADCAST, org_z);
 		}
 	}
 }

--- a/portals/weapons.hc
+++ b/portals/weapons.hc
@@ -594,7 +594,7 @@ float W_CheckNoAmmo (float check_weapon)
 				if(self.bluemana >= 8 && self.greenmana >= 8)
 					return TRUE;
 			}
-			else if(self.bluemana >= 2 && self.greenmana >= 2)
+			else if(self.bluemana >= 1 && self.greenmana >= 1)
 					return TRUE;
 		break;
 		case IT_WEAPON3:


### PR DESCRIPTION
Prevent backpacks from giving more than the maximum of any item they contain; offset sickle tomed flash fx so it doesn't spawn in wall; add wall impact fx for warhammer; correct minimum mana needed to select purifier (prev. 2 each) to reflect the amount needed to fire one shot (1 each)

The backpacks appear to already be fixed in hexenworld's hc, so i left that alone