### PR TITLE
Fix dropped armor & wizard pain state

### DIFF
--- a/h2/items.hc
+++ b/h2/items.hc
@@ -817,6 +817,7 @@ void spawn_item_armor_helmet(void)
 	self.hull=HULL_POINT;
 	self.touch = armor_touch;
 	self.netname = STR_ARMORHELMET;
+	self.classname = "item_armor_helmet";	//ws: enforce classname here because otherwise armor dropped by monsters doesn't count as armor to armor_touch
 
 	StartItem ();
 }
@@ -838,6 +839,7 @@ void spawn_item_armor_breastplate (void)
 	self.hull=HULL_POINT;
 	self.touch = armor_touch;
 	self.netname = STR_ARMORBREASTPLATE;
+	self.classname = "item_armor_breastplate";
 
 	StartItem ();
 }
@@ -859,6 +861,7 @@ void spawn_item_armor_bracer(void)
 	self.hull=HULL_POINT;
 	self.touch = armor_touch;
 	self.netname = STR_ARMORBRACER;
+	self.classname = "item_armor_bracer";
 
 	StartItem ();
 }
@@ -880,6 +883,7 @@ void spawn_item_armor_amulet(void)
 	self.hull=HULL_POINT;
 	self.touch = armor_touch;
 	self.netname = STR_ARMORAMULET;
+	self.classname = "item_armor_amulet";
 
 	StartItem ();
 }

--- a/h2/skullwiz.hc
+++ b/h2/skullwiz.hc
@@ -449,9 +449,9 @@ void skullwiz_pain_anim () [++ $skpain1 .. $skpain12]
 		else
 			sound (self, CHAN_BODY, "skullwiz/pain2.wav", 1, ATTN_NORM);
 	}
-
-	if (self.frame < $skpain11)
-		self.frame += 1;
+	//ws: frame advance is handled automatically by the function, so the following skipped most frames (including the frame with pain sound)
+	//if (self.frame < $skpain11)
+		//self.frame += 1;
 
 	if (self.frame>=$skpain12)
 	{

--- a/portals/items.hc
+++ b/portals/items.hc
@@ -869,6 +869,7 @@ void spawn_item_armor_helmet(void)
 	self.hull=HULL_POINT;
 	self.touch = armor_touch;
 	self.netname = STR_ARMORHELMET;
+	self.classname = "item_armor_helmet";	//ws: enforce classname here because otherwise armor dropped by monsters doesn't count as armor to armor_touch
 
 	StartItem ();
 }
@@ -890,6 +891,7 @@ void spawn_item_armor_breastplate (void)
 	self.hull=HULL_POINT;
 	self.touch = armor_touch;
 	self.netname = STR_ARMORBREASTPLATE;
+	self.classname = "item_armor_breastplate";
 
 	StartItem ();
 }
@@ -911,6 +913,7 @@ void spawn_item_armor_bracer(void)
 	self.hull=HULL_POINT;
 	self.touch = armor_touch;
 	self.netname = STR_ARMORBRACER;
+	self.classname = "item_armor_bracer";
 
 	StartItem ();
 }
@@ -932,6 +935,7 @@ void spawn_item_armor_amulet(void)
 	self.hull=HULL_POINT;
 	self.touch = armor_touch;
 	self.netname = STR_ARMORAMULET;
+	self.classname = "item_armor_amulet";
 
 	StartItem ();
 }

--- a/portals/skullwiz.hc
+++ b/portals/skullwiz.hc
@@ -450,9 +450,9 @@ void skullwiz_pain_anim () [++ $skpain1 .. $skpain12]
 		else
 			sound (self, CHAN_BODY, "skullwiz/pain2.wav", 1, ATTN_NORM);
 	}
-
-	if (self.frame < $skpain11)
-		self.frame += 1;
+	//ws: frame advance is handled automatically by the function, so the following skipped most frames (including the frame with pain sound)
+	//if (self.frame < $skpain11)
+		//self.frame += 1;
 
 	if (self.frame>=$skpain12)
 	{


### PR DESCRIPTION
1. Dropped armor: Before, armor dropped by monsters wouldn't actually give the player armor when collected because it didn't have the proper classname.

2.  Skull Wizard: Before, half the frames in his pain animation were skipped (including the one that plays his pain sound).