### PR TITLE
let Golem gibs spawn

### DIFF
--- a/h2/golem.hc
+++ b/h2/golem.hc
@@ -1352,25 +1352,25 @@ void GolemDeathFinish(void) [++ $death12..$death22]
 		{ // Assumed bronze
 			sound(self, CHAN_BODY, "golem/mtlfall.wav", 1, ATTN_NORM);
 		}
-
-
+		/*
 		if (GolemCheckSolidGround())
 		{
 			GolemChunkDeath();
-			//MakeSolidCorpse();
 		}
 		else
 		{
 			self.think = chunk_death;
 			thinktime self : 0.1;
 		}
-
+		*/
+		
+		GolemChunkDeath();
 		return;
 	}
 	
 	if(self.frame == $death16)
 	{
-		self.solid = SOLID_NOT;
+		self.solid = SOLID_PHASE;
 	}
 	
 	if (self.frame > $death16)
@@ -1379,7 +1379,7 @@ void GolemDeathFinish(void) [++ $death12..$death22]
 		self.origin += v_forward * 4;
 	}
 
-	if(self.health < -50)
+	if(self.health < -60)
 	{
 		self.think = chunk_death;
 	}

--- a/portals/golem.hc
+++ b/portals/golem.hc
@@ -1423,25 +1423,25 @@ void GolemDeathFinish(void) [++ $death12..$death22]
 		{ // Assumed bronze
 			sound(self, CHAN_BODY, "golem/mtlfall.wav", 1, ATTN_NORM);
 		}
-
-
+		/*
 		if (GolemCheckSolidGround())
 		{
 			GolemChunkDeath();
-			//MakeSolidCorpse();
 		}
 		else
 		{
 			self.think = chunk_death;
 			thinktime self : 0.1;
 		}
-
+		*/
+		
+		GolemChunkDeath();
 		return;
 	}
 	
 	if(self.frame == $death16)
 	{
-		self.solid = SOLID_NOT;
+		self.solid = SOLID_PHASE;
 	}
 	
 	if (self.frame > $death16)
@@ -1450,7 +1450,7 @@ void GolemDeathFinish(void) [++ $death12..$death22]
 		self.origin += v_forward * 4;
 	}
 
-	if(self.health < -50)
+	if(self.health < -60)
 	{
 		self.think = chunk_death;
 	}


### PR DESCRIPTION
The Golem monster's death animation used a special function to check for room to spawn its special chunks (head & limbs). However, the function always returned false even if they're in a flat, open area. Now they will spawn properly.