### PR TITLE
Fix weretiger precache in ai.hc

### DIFF
--- a/portals/ai.hc
+++ b/portals/ai.hc
@@ -1003,7 +1003,7 @@ float have_monsters;
 	{
 		precache_model4 ("models/snowleopard.mdl");
 		precache_model2 ("models/mezzoref.spr");
-		precache_model2 ("models/h_mez.mdl");
+		precache_model2 ("models/h_mez2.mdl");
 		precache_sound2 ("mezzo/skid.wav");
 		precache_sound2 ("mezzo/roar.wav");
 		precache_sound2 ("mezzo/reflect.wav");


### PR DESCRIPTION
At line 1002 the precaches for the weretiger were obviously copypasted from those for the snowleopard.
Notably the head model was h_mez.mdl as well, whereas it should be h_mez2.mdl instead.

So if the weretiger's death animation would require its head model, which was improperly set to the snow leopard's one, it would cause the game to suddenly crash.
It seems it's not so easy to gib a weretiger, hence the bug having been able to survive 25 years without having been noticed but still...